### PR TITLE
Speed up message extraction by using one rule (one pass) instead of 4

### DIFF
--- a/lib/defaultConfig.js
+++ b/lib/defaultConfig.js
@@ -1,9 +1,6 @@
 module.exports = {
     stringsRules: [
-            /intl\.formatMessage\s*?\(\s*?(['`"])([\s\S]+?)\1\s*?(?=[,\)])/g,
-        /intl\.formatHTMLMessage\s*?\(\s*?(['`"])([\s\S]+?)\1\s*?(?=[,\)])/g,
-              /\{\{formatMessage\s*?\(\s*?(['`"])([\s\S]+?)\1\s*?(?=[,\)])/g,
-          /\{\{formatHTMLMessage\s*?\(\s*?(['`"])([\s\S]+?)\1\s*?(?=[,\)])/g
+        /(?:intl\.|\{\{)format(?:HTML)?Message\s*?\(\s*?(['`"])([\s\S]+?)\1\s*?(?=[,\)])/g
     ],
     scopeRules: [
         /\/\/\s*intlScope:\s*([\-\w\.]+)/g,


### PR DESCRIPTION
Running `tau-extract-gettext.cmd scripts/tau`
Time with 4 rules: getScope: 33s, tokenize: 86s, tokenizeJsx: 321ms
Time with 1 rule: getScope: 33s, tokenize: 20s, tokenizeJsx: 313ms